### PR TITLE
Middleend/fix lock file

### DIFF
--- a/Code/poetry.lock
+++ b/Code/poetry.lock
@@ -2622,5 +2622,5 @@ requests = "*"
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.14.0"
-content-hash = "efb2f314d3fce9410228223666c5af5c42a2a7c718176eb6675929d817cdd94a"
+python-versions = "==3.14.0"
+content-hash = "31f17cb4d7c21f5337f5ebe4ecec19bda597b64c9bc097f5761d1972be7157ec"

--- a/Code/pyproject.toml
+++ b/Code/pyproject.toml
@@ -7,45 +7,45 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.14.0"
+python = "==3.14.0"
 
 # django framework
-django = "^5.2.7"
-djangorestframework = "^3.16.1"
-django-debug-toolbar = "^6.0.0"
+django = "==5.2.7"
+djangorestframework = "==3.16.1"
+django-debug-toolbar = "==6.0.0"
 
 # Tool for HTTP requests
-requests = "^2.32.5"
+requests = "==2.32.5"
 
 # Tool for loading env file variables
-python-dotenv = "^1.1.1"
+python-dotenv = "==1.1.1"
 
 
 # Image processing tool
-pillow = "^12.0.0"
+pillow = "==12.0.0"
 
 # Location
-geopy = "^2.4.1"
-geoip2 = "^5.1.0"
+geopy = "==2.4.1"
+geoip2 = "==5.1.0"
 
 # Yelp
-yelpapi = "^2.5.1"
+yelpapi = "==2.5.1"
 
 # Text to Speech
-speechrecognition = "^3.14.3"
+speechrecognition = "==3.14.3"
 
 # AI tools
-transformers = "^4.57.1"
+transformers = "==4.57.1"
 
 # Phone calls/text management 
-twilio = "^9.8.4"
-sendgrid = "^6.12.5"
+twilio = "==9.8.4"
+sendgrid = "==6.12.5"
 
 # Code testing
-selenium = "^4.37.0"
+selenium = "==4.37.0"
 
 # Payment processing
-stripe = "^13.0.1"
+stripe = "==13.0.1"
 
 
 [build-system]


### PR DESCRIPTION
Okay I tightened all of the version constraints so that it has to install exactly the version that is in the toml file. This should make it all more stable for everyone.

And the new lock file is that one that was generated from said tight constraints.